### PR TITLE
chore: remove dependabot reviewers and use CODEOWNERS instead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/about-codeowners/
+
+- @Fingertips18

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,11 @@ updates:
   - package-ecosystem: "npm"
     directory: /
     schedule:
-      interval: "daily" # Check for updates every day
+      interval: "daily"
     commit-message:
-      prefix: "chore" # Use 'chore' prefix for the commit message
-      include: "scope" # Include the scope (dependency name) in the commit message
-    reviewers:
-      - Fingertips18
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10
 
   # Update npm dependencies in the client directory
   - package-ecosystem: "npm"
@@ -19,5 +18,14 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    reviewers:
-      - Fingertips18
+    open-pull-requests-limit: 10
+
+  # Update GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: chore
+      include: scope
+    open-pull-requests-limit: 10


### PR DESCRIPTION
- Refactored the `.github/dependabot.yml` by removing the deprecated `reviewers` field in compliance with GitHub’s deprecation notice.
- Added a `CODEOWNERS` file to define default reviewers for Dependabot PRs and other pull requests, following the updated recommended configuration.

Reference: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners