### PR TITLE
ci(ping-site): Add scheduled ping job to keep site active

### DIFF
--- a/.github/workflows/ping.yaml
+++ b/.github/workflows/ping.yaml
@@ -1,0 +1,16 @@
+name: Ping Site
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # Every 30 minutes UTC
+  workflow_dispatch: # Allow manual trigger too
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Random Delay (0–119 seconds)
+        run: sleep $((RANDOM % 120))
+
+      - name: Site Visit
+        run: curl -s --fail https://mern-auth-tau7.onrender.com || echo "Ping failed"


### PR DESCRIPTION
- Created a GitHub Actions workflow that runs every 30 minutes
- Sends a lightweight HTTP request to the deployed Render app to reduce idle spin-down
- Introduced a randomized delay to avoid predictable traffic patterns
- Includes manual trigger support via workflow_dispatch

This setup helps keep the app more responsive on Render's free tier while respecting fair-use guidelines.