### PR TITLE
chore: prod fix release

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -30,7 +30,7 @@ app.use(Routes.auth.path, authRoutes);
 if (process.env.NODE_ENV === "production") {
   app.use(express.static(path.join(__dirname, "/frontend/dist")));
 
-  app.get("*", (_, res) => {
+  app.get("/*splat", (_, res) => {
     res.sendFile(path.resolve(__dirname, "frontend", "dist", "index.html"));
   });
 }


### PR DESCRIPTION
Replaced legacy wildcard path `*` with named wildcard `/*splat` in production catch-all route to comply with Express 5 path-to-regexp changes.