### PR TITLE
chore(tailwind): migrate from deprecated bg-opacity-* to new v4 syntax

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,25 +39,7 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
-}
 
-@utility flex-center {
-  @apply flex items-center justify-center;
-}
-
-@utility flex-between {
-  @apply flex items-center justify-between;
-}
-
-@utility flex-start {
-  @apply flex items-center justify-start;
-}
-
-@utility flex-end {
-  @apply flex items-center justify-end;
-}
-
-@layer base {
   :root {
     --background: #fafbfb;
     --foreground: #0f1113;
@@ -81,4 +63,20 @@
   body {
     @apply p-0 m-0 bg-background text-foreground font-poppins;
   }
+}
+
+@utility flex-center {
+  @apply flex items-center justify-center;
+}
+
+@utility flex-between {
+  @apply flex items-center justify-between;
+}
+
+@utility flex-start {
+  @apply flex items-center justify-start;
+}
+
+@utility flex-end {
+  @apply flex items-center justify-end;
 }

--- a/frontend/src/pages/forgot-password/page.jsx
+++ b/frontend/src/pages/forgot-password/page.jsx
@@ -16,7 +16,7 @@ const ForgotPasswordPage = () => {
       transition={{
         duration: 0.5,
       }}
-      className="max-w-md w-full bg-secondary bg-opacity-20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl overflow-hidden mx-4 lg:mx-0"
+      className="max-w-md w-full bg-secondary/20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl overflow-hidden mx-4 lg:mx-0"
     >
       <div className="p-4 lg:p-8">
         <h2 className="text-3xl font-bold mb-6 text-center bg-clip-text">
@@ -30,7 +30,7 @@ const ForgotPasswordPage = () => {
 
         <ForgotPasswordForm />
       </div>
-      <div className="px-8 py-4 bg-dark-secondary bg-opacity-40 flex-center">
+      <div className="px-8 py-4 bg-dark-secondary/40 flex-center">
         <Link
           to={AppRoutes.root}
           className="text-sm text-dark-accent hover:underline underline-offset-4 font-semibold"

--- a/frontend/src/pages/not-found/page.jsx
+++ b/frontend/src/pages/not-found/page.jsx
@@ -7,7 +7,7 @@ const NotFoundPage = () => {
   const navigate = useNavigate();
 
   return (
-    <section className="space-y-2 bg-secondary bg-opacity-50 backdrop-blur-md drop-shadow-2xl rounded-lg p-6">
+    <section className="space-y-2 bg-secondary/50 backdrop-blur-md drop-shadow-2xl rounded-lg p-6">
       <h3 className="text-lg font-semibold drop-shadow-foreground-glow">
         404 | Page not found
       </h3>

--- a/frontend/src/pages/reset-password/page.jsx
+++ b/frontend/src/pages/reset-password/page.jsx
@@ -13,7 +13,7 @@ const ResetPasswordPage = () => {
       transition={{
         duration: 0.5,
       }}
-      className="max-w-md w-full bg-secondary bg-opacity-20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl mx-4 lg:mx-0"
+      className="max-w-md w-full bg-secondary/20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl mx-4 lg:mx-0"
     >
       <div className="p-4 lg:p-8">
         <h2 className="text-3xl font-bold mb-6 text-center bg-clip-text">

--- a/frontend/src/pages/root/_components/profile-activity.jsx
+++ b/frontend/src/pages/root/_components/profile-activity.jsx
@@ -16,7 +16,7 @@ const ProfileActivity = ({ lastSignedIn, createdAt }) => {
       transition={{
         delay: 0.5,
       }}
-      className="p-4 bg-primary bg-opacity-50 rounded-lg backdrop-blur-md border border-primary"
+      className="p-4 bg-primary/50 rounded-lg backdrop-blur-md border border-primary"
     >
       <h3 className="text-lg font-extrabold mb-3">Account Activity</h3>
       <p className="capitalize font-medium">

--- a/frontend/src/pages/root/_components/profile-information.jsx
+++ b/frontend/src/pages/root/_components/profile-information.jsx
@@ -14,7 +14,7 @@ const ProfileInformation = ({ username, email }) => {
       transition={{
         delay: 0.5,
       }}
-      className="p-4 bg-primary bg-opacity-50 rounded-lg backdrop-blur-md border border-primary"
+      className="p-4 bg-primary/50 rounded-lg backdrop-blur-md border border-primary"
     >
       <h3 className="text-lg font-extrabold mb-3">Profile Information</h3>
       <p className="capitalize font-medium">

--- a/frontend/src/pages/root/page.jsx
+++ b/frontend/src/pages/root/page.jsx
@@ -9,7 +9,7 @@ const RootPage = () => {
   const { user } = useAuthStore();
 
   return (
-    <section className="h-full z-50 relative p-4 lg:p-6 space-y-4 backdrop-blur-lg rounded-lg bg-primary bg-opacity-20 drop-shadow-2xl mx-4 lg:mx-0">
+    <section className="h-full z-50 relative p-4 lg:p-6 space-y-4 backdrop-blur-lg rounded-lg bg-primary/20 drop-shadow-2xl mx-4 lg:mx-0">
       <Title />
       <ProfileInformation username={user.username} email={user.email} />
       <ProfileActivity

--- a/frontend/src/pages/sign-in/page.jsx
+++ b/frontend/src/pages/sign-in/page.jsx
@@ -16,7 +16,7 @@ const SignInPage = () => {
       transition={{
         duration: 0.5,
       }}
-      className="max-w-md w-full bg-secondary bg-opacity-20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl overflow-hidden mx-4 lg:mx-0"
+      className="max-w-md w-full bg-secondary/20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl overflow-hidden mx-4 lg:mx-0"
     >
       <div className="p-4 lg:p-8">
         <h2 className="text-3xl font-bold mb-6 text-center bg-clip-text">
@@ -25,7 +25,7 @@ const SignInPage = () => {
 
         <SignInForm />
       </div>
-      <div className="px-8 py-4 bg-dark-secondary bg-opacity-40 flex-center">
+      <div className="px-8 py-4 bg-dark-secondary/40 flex-center">
         <p className="text-sm text-dark-foreground">
           Don&apos;t have an account?{" "}
           <Link

--- a/frontend/src/pages/sign-up/page.jsx
+++ b/frontend/src/pages/sign-up/page.jsx
@@ -16,7 +16,7 @@ const SignUpPage = () => {
       transition={{
         duration: 0.5,
       }}
-      className="max-w-md w-full bg-secondary bg-opacity-20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl overflow-hidden mx-4 lg:mx-0"
+      className="max-w-md w-full bg-secondary/20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl overflow-hidden mx-4 lg:mx-0"
     >
       <div className="p-4 lg:p-8">
         <h2 className="text-3xl font-bold mb-6 text-center bg-clip-text">
@@ -25,7 +25,7 @@ const SignUpPage = () => {
 
         <SignUpForm />
       </div>
-      <div className="px-8 py-4 bg-dark-secondary bg-opacity-40 flex-center">
+      <div className="px-8 py-4 bg-dark-secondary/40 flex-center">
         <p className="text-sm text-dark-foreground">
           Already have an account?{" "}
           <Link

--- a/frontend/src/pages/verify-email/_components/verify-email-form.jsx
+++ b/frontend/src/pages/verify-email/_components/verify-email-form.jsx
@@ -93,7 +93,7 @@ const VerifyEmailForm = () => {
             onChange={(e) => onChange(e.target.value, i)}
             onKeyDown={(e) => onKeyDown(e, i)}
             autoComplete="off"
-            className="w-12 h-12 text-center text-2xl font-bold bg-secondary bg-opacity-50 rounded-lg border border-secondary outline-hidden
+            className="w-12 h-12 text-center text-2xl font-bold bg-secondary/50 rounded-lg border border-secondary outline-hidden
             focus:border-primary/20 focus:ring-2 focus:ring-primary placeholder-foreground/40 transition duration-200"
           />
         ))}

--- a/frontend/src/pages/verify-email/page.jsx
+++ b/frontend/src/pages/verify-email/page.jsx
@@ -13,7 +13,7 @@ const VerifyEmailPage = () => {
       transition={{
         duration: 0.5,
       }}
-      className="max-w-md w-full bg-secondary bg-opacity-20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl overflow-hidden mx-4 lg:mx-0"
+      className="max-w-md w-full bg-secondary/20 backdrop-filter backdrop-blur-md rounded-lg shadow-2xl overflow-hidden mx-4 lg:mx-0"
     >
       <div className="p-4 lg:p-8">
         <h2 className="text-3xl font-bold mb-2 text-center bg-clip-text">


### PR DESCRIPTION
- Removed all instances of `bg-opacity-*` classes which are deprecated in **Tailwind v4**.
- Replaced them with the new `[color]/[opacity]` format, e.g., `bg-black/50` instead of `bg-black bg-opacity-50`.
- Ensures styles remain visually consistent after upgrade.
- Verified across all components and pages using background opacity utilities.
- Part of the broader Tailwind CSS v4 migration effort.