### PR TITLE
refactor(log): warn instead of error on 401 token verification failures

### DIFF
--- a/frontend/src/lib/services/auth.service.js
+++ b/frontend/src/lib/services/auth.service.js
@@ -92,11 +92,17 @@ const AuthService = {
   },
   verifyToken: async () => {
     try {
-      const response = await axios.get(`${baseUrl}${AppRoutes.verifyToken}`);
+      const response = await axios.get(`${baseUrl}${AppRoutes.verifyToken}`, {
+        withCredentials: true,
+      });
 
       return { user: response.data.user, message: response.data.message };
     } catch (error) {
-      console.error(error);
+      if (error.response.status === 401) {
+        console.warn(error);
+      } else {
+        console.error(error);
+      }
       throw error.response.data.message;
     }
   },


### PR DESCRIPTION
- Updated the `verifyToken` service to differentiate logging based