### PR TITLE
chore: skip already reviewed dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-coderabbit-review.yaml
+++ b/.github/workflows/dependabot-coderabbit-review.yaml
@@ -23,6 +23,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
 
             // Check if we've already commented
@@ -38,6 +39,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `${marker}
-                @coderabbitai Are there any breaking changes in this dependency update? Is it safe to merge?`
+              body: `${marker}\n@coderabbitai Are there any breaking changes in this dependency update? Is it safe to merge?`
             });

--- a/.github/workflows/dependabot-coderabbit-review.yaml
+++ b/.github/workflows/dependabot-coderabbit-review.yaml
@@ -16,9 +16,28 @@ jobs:
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
+            const marker = '<!-- coderabbitai-review-request -->';
+
+            // Fetch existing comments
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            // Check if we've already commented
+            const alreadyCommented = comments.some(comment => comment.body.includes(marker));
+
+            if (alreadyCommented) {
+              console.log('Coderabbit comment already exists. Skipping.');
+              return;
+            }
+
+            // Create the comment if not found
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '@coderabbitai Are there any breaking changes in this dependency update? Is it safe to merge?'
+              body: `${marker}
+                @coderabbitai Are there any breaking changes in this dependency update? Is it safe to merge?`
             });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prevents duplicate review requests from the workflow by adding an idempotent marker and check before posting reviewer comments; updates comment content to include the marker and reviewer mention.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->